### PR TITLE
Restore previous work on concatenated gzip streams

### DIFF
--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -50,6 +50,25 @@ public class GZIPInputStream extends InflaterInputStream {
     super(in, inflater, size, close_in);
   }
 
+  public int read(byte[] b, int off, int len) throws IOException {
+    int i = super.read(b, off, len);
+    if(i == -1){
+      if(inflater.avail_in<2){
+        int l = in.read(buf, 0, buf.length);
+        if(l>0)
+          inflater.setInput(buf, 0, l, true);
+      }
+      if(inflater.avail_in>2 &&
+         ((inflater.next_in[inflater.next_in_index]&0xff) == 0x1f) &&
+         ((inflater.next_in[inflater.next_in_index+1]&0xff) == (0x8b&0xff))){
+        this.inflater.reset();
+        this.eof=false;
+        return super.read(b, off, len);
+      }
+    } 
+    return i;
+  }
+
   /**
    * @deprecated use getModifiedTime()
    * @return long modified time.

--- a/src/main/java/com/jcraft/jzlib/Inflater.java
+++ b/src/main/java/com/jcraft/jzlib/Inflater.java
@@ -57,6 +57,10 @@ final public class Inflater extends ZStream{
   static final private int Z_BUF_ERROR=-5;
   static final private int Z_VERSION_ERROR=-6;
 
+  private int param_w = -1;
+  private JZlib.WrapperType param_wrapperType = null;
+  private boolean param_nowrap = false;
+
   public Inflater() {
     super();
     init();
@@ -68,6 +72,8 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, JZlib.WrapperType wrapperType) throws GZIPException {
     super();
+    param_w = w;
+    param_wrapperType = wrapperType;
     int ret = init(w, wrapperType);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
@@ -83,9 +89,21 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, boolean nowrap) throws GZIPException {
     super();
+    param_w = w;
+    param_nowrap = nowrap;
     int ret = init(w, nowrap);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
+  }
+
+  void reset() {
+    finished = false;
+    if(param_wrapperType != null){
+      init(param_w, param_wrapperType);
+    }
+    else {
+      init(param_w, param_nowrap);
+    }
   }
 
   private boolean finished = false;

--- a/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
@@ -36,7 +36,7 @@ public class InflaterInputStream extends FilterInputStream {
 
   private boolean closed = false;
 
-  private boolean eof = false;
+  protected boolean eof = false;
 
   private boolean close_in = true;
 

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -90,4 +90,27 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     csIn.getValue() should equal(csOut.getValue)
   }
+
+  behavior of "GZIPInputStream"
+
+  it can "inflate a concatenated gzip stream." in {
+    // echo -n "a" | gzip > data
+    // echo -n "b" | gzip >> data
+    // echo -n "c" | gzip >> data
+    val data =  {
+     val baos1 = new ByteArrayOutputStream
+      List("a", "b", "c").map{s =>
+        val gos = new GZIPOutputStream(baos1)
+        gos.write(s.getBytes);
+        gos.close
+      }
+      baos1.toByteArray
+    }
+
+    val gis = new GZIPInputStream(new ByteArrayInputStream(data))
+    val baos = new ByteArrayOutputStream()
+    gis -> baos
+
+    baos.toByteArray should equal("abc".getBytes)
+  }
 }


### PR DESCRIPTION
The code here as-is broke two JRuby tests:

```
  1) Failure:
TestZlibGzipFile#test_gzip_reader_zcat [/home/runner/work/jruby/jruby/test/mri/zlib/test_zlib.rb:594]:
<["foo", "bar"]> expected but was
<["foobar"]>.

  2) Failure:
TestZlibGzipReader#test_unused2 [/home/runner/work/jruby/jruby/test/mri/zlib/test_zlib.rb:960]:
<"aaaa"> expected but was
<"aaaabbbb">.
```

I reverted it for 1.1.5 but preserve the work here.

See https://github.com/ymnk/jzlib/commit/0c1c243f2a1e7546a765e72562c4e09ae27f32ce for the original branch by @ymnk.